### PR TITLE
fix: expose only public open handler

### DIFF
--- a/assets/js/accounts.js
+++ b/assets/js/accounts.js
@@ -396,7 +396,7 @@
     });
 
     // Expose handlers
-    window.AccountsUI = Object.assign(window.AccountsUI || {}, { open, close });
+    window.AccountsUI = Object.assign(window.AccountsUI || {}, { close /* , open: openAndLoad */ });
   }
 
   // Public API


### PR DESCRIPTION
## Summary
- remove stray `open` exposure from internal AccountsUI handler assignment
- keep public `open` API as sole opening method for modal

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948ebfa1dc83339467356e7d35d714