### PR TITLE
Remove redundant Accounts button handler

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -202,10 +202,10 @@ function wireEvents() {
   document.addEventListener("click", () => {
     if (periodDropdown) periodDropdown.classList.remove("open");
   });
-  // Accounts button opens modal
-  if (openAccountsBtn && window.AccountsUI && window.AccountsUI.open) {
-    openAccountsBtn.addEventListener("click", () => window.AccountsUI.open());
-  }
+  // Accounts button is wired in accounts.js
+  // if (openAccountsBtn && window.AccountsUI && window.AccountsUI.open) {
+  //   openAccountsBtn.addEventListener("click", () => window.AccountsUI.open());
+  // }
 
   if (themeToggle) themeToggle.addEventListener("click", toggleTheme);
 


### PR DESCRIPTION
## Summary
- Remove click handler for Accounts button from app.js so accounts.js is sole wiring source.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68948ec03e2483338d19cab5e55202f5