### PR TITLE
Fix Accounts modal injection

### DIFF
--- a/assets/js/accounts.js
+++ b/assets/js/accounts.js
@@ -204,7 +204,7 @@
     injectStylesOnce();
     const wrapper = document.createElement("div");
     wrapper.innerHTML = TEMPLATE;
-    const node = wrapper.firstChild;
+    const node = wrapper.firstElementChild;
     document.body.appendChild(node);
     console.debug("Accounts: injected backdrop =", !!document.getElementById("accountsModalBackdrop"));
 


### PR DESCRIPTION
## Summary
- ensure Accounts modal injects the actual backdrop element

## Testing
- `node - <<'NODE'
const {JSDOM} = require('jsdom');
const fs = require('fs');
const dom = new JSDOM('<!DOCTYPE html><body></body>', { runScripts: 'outside-only' });
dom.window.alert=()=>{};
dom.window.eval(fs.readFileSync('/workspace/trading-journal/assets/js/accounts.js','utf-8'));
dom.window.AccountsUI.injectModal();
console.log(!!dom.window.document.getElementById('accountsModalBackdrop'));
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68948ebec4848333805dd6d39bf21954