### PR TITLE
Remove redundant Accounts button handler

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -203,9 +203,10 @@ function wireEvents() {
     if (periodDropdown) periodDropdown.classList.remove("open");
   });
   // Accounts button opens modal
-  if (openAccountsBtn && window.AccountsUI && window.AccountsUI.open) {
-    openAccountsBtn.addEventListener("click", () => window.AccountsUI.open());
-  }
+  // Handled exclusively in assets/js/accounts.js
+  // if (openAccountsBtn && window.AccountsUI && window.AccountsUI.open) {
+  //   openAccountsBtn.addEventListener("click", () => window.AccountsUI.open());
+  // }
 
   if (themeToggle) themeToggle.addEventListener("click", toggleTheme);
 


### PR DESCRIPTION
## Summary
- Comment out duplicate Accounts modal button handler in app.js so accounts.js is the single binding source.

## Testing
- `node test-openAccounts.js` *(jsdom simulation to verify modal still opens on click)*

------
https://chatgpt.com/codex/tasks/task_e_68948c9a62348333840d7a031a905d1e