### PR TITLE
feat: add realtime trade updates

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,4 +1,4 @@
-import { DataStore, Session, Selectors, computeKpis, filterTradesByPeriod, setSelectedAccount } from "./state.js";
+import { DataStore, Session, Selectors, computeKpis, filterTradesByPeriod, setSelectedAccount, subscribeToTrades } from "./state.js";
 import { renderRecentTrades, renderGoals, setKpi } from "./components.js";
 import { fmt } from "./utils.js";
 import { makeEquityChart, makeWinrateChart, makePnlBars, makePie, updateChart } from "./charts.js";
@@ -215,6 +215,7 @@ function init() {
     hydrateSelectors();
     hydrateHeaderAccountSelect(); // ensure account selector exists and synced
     ensureHeaderNickname();
+    subscribeToTrades();
     hydrateNotes();
     hydrateGoals();
     wireEvents();

--- a/assets/js/journal.js
+++ b/assets/js/journal.js
@@ -1,4 +1,4 @@
-import { DataStore, Session, Selectors, listTrades, createTrade, updateTrade, deleteTrade, setSelectedAccount } from "./state.js";
+import { DataStore, Session, Selectors, listTrades, createTrade, updateTrade, deleteTrade, setSelectedAccount, subscribeToTrades } from "./state.js";
 import { fmt } from "./utils.js";
 
 const DATE_FORMAT = "DD-MM-YYYY";
@@ -716,6 +716,7 @@ async function init() {
   try {
     if (typeof Selectors?.refreshAccountsFromSupabase === "function") {
       await Selectors.refreshAccountsFromSupabase();
+      subscribeToTrades();
       console.log("Journal: accounts loaded from Supabase via Selectors.refreshAccountsFromSupabase");
     } else {
       console.warn("Journal: no explicit loader for Supabase accounts; using Selectors.getAccounts()");

--- a/assets/js/state.js
+++ b/assets/js/state.js
@@ -202,6 +202,56 @@ export async function deleteTrade(id) {
   document.dispatchEvent(new CustomEvent("tj.trades.changed", { detail: { type: "delete", id } }));
 }
 
+let tradesChannel = null;
+
+export function subscribeToTrades() {
+  const client = window.supabaseClient || (window.auth && window.auth.supabase);
+  if (!client || !client.channel) return null;
+
+  if (tradesChannel) try { tradesChannel.unsubscribe(); } catch {}
+
+  tradesChannel = client
+    .channel('any')
+    .on('postgres_changes', { event: '*', schema: 'public', table: 'trades_new' }, payload => {
+      const evt = payload.eventType;
+      if (evt === 'DELETE') {
+        const id = payload.old?.id;
+        if (id) {
+          DataStore.trades = DataStore.trades.filter(t => t.id !== id);
+          document.dispatchEvent(new CustomEvent('tj.trades.changed', { detail: { type: 'delete', id } }));
+        }
+        return;
+      }
+
+      const r = payload.new;
+      if (!r) return;
+      const trade = {
+        id: r.id,
+        accountId: r.account || null,
+        symbol: r.pair || '',
+        strategy: '',
+        qty: 1,
+        r: Number(r.rr ?? 0),
+        pnl: Number(r.net_result_usd ?? 0),
+        entryAt: r.started_at ? String(r.started_at).slice(0, 10) : null,
+        exitAt: r.ended_at ? String(r.ended_at).slice(0, 10) : r.started_at ? String(r.started_at).slice(0, 10) : null,
+        fees: 0,
+        notes: r.notes || '',
+        tags: []
+      };
+      const idx = DataStore.trades.findIndex(t => t.id === trade.id);
+      if (idx >= 0) DataStore.trades[idx] = trade; else DataStore.trades.unshift(trade);
+      document.dispatchEvent(new CustomEvent('tj.trades.changed', { detail: { type: evt.toLowerCase(), id: trade.id } }));
+    })
+    .subscribe();
+
+  window.addEventListener('beforeunload', () => {
+    try { tradesChannel.unsubscribe(); } catch {}
+  }, { once: true });
+
+  return tradesChannel;
+}
+
 export function computeKpis(trades, startingEquity, currency) {
   const totalPnl = sum(trades, t => t.pnl);
   const equity = (startingEquity || 0) + totalPnl;


### PR DESCRIPTION
## Summary
- add subscribeToTrades helper for realtime Supabase channel
- hook subscription into dashboard and journal init flows

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895ea4591408333a3ab0916888d1e7c