### PR TITLE
Fix broken sidebar links for missing pages

### DIFF
--- a/accounts.html
+++ b/accounts.html
@@ -38,19 +38,19 @@
           </span>
           <span>Журнал</span>
         </a>
-        <a href="analytics.html" class="sb-link">
+          <a href="index.html#/analytics" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18" stroke-width="2"/><path d="M7 16v2M12 10v8M17 6v12" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Аналитика</span>
         </a>
-        <a href="calendar.html" class="sb-link">
+          <a href="index.html#/calendar" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="5" width="18" height="16" rx="2" stroke-width="2"/><path d="M16 3v4M8 3v4M3 10h18" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Календарь</span>
         </a>
-        <a href="goals.html" class="sb-link">
+          <a href="index.html#/goals" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9" stroke-width="2"/><path d="M12 7v10M7 12h10" stroke-width="2" stroke-linecap="round"/></svg>
           </span>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -8,6 +8,7 @@ import { makeEquityChart, makeWinrateChart, makePnlBars, makePie, updateChart } 
  * Pages: #/dashboard (default), #/journal, #/analytics, #/calendar, #/goals, #/accounts
  */
 const viewEl = document.getElementById("view");
+const dashMain = document.querySelector("main.dashboard");
 const sidebar = document.getElementById("sidebar");
 const sbBurger = document.getElementById("sbBurger");
 const sbClose = document.getElementById("sbClose");
@@ -40,6 +41,12 @@ function setActiveNav(path) {
 }
 function mountPage(path) {
   setActiveNav(path);
+  const isDash = path === "dashboard";
+  if (dashMain) dashMain.style.display = isDash ? "" : "none";
+  if (viewEl) {
+    viewEl.style.display = isDash ? "none" : "";
+    if (!isDash) viewEl.innerHTML = "";
+  }
   switch (path) {
     case "journal":
       pageTitle && (pageTitle.textContent = "Журнал");

--- a/index.html
+++ b/index.html
@@ -53,37 +53,37 @@
         <button id="sbClose" class="btn ghost icon" aria-label="Close menu">✕</button>
       </div>
       <nav class="sb-nav">
-        <a href="index.html" class="sb-link">
+          <a href="#/dashboard" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3h8v8H3zM13 3h8v8h-8zM13 13h8v8h-8zM3 13h8v8H3z" stroke-width="2" stroke-linejoin="round"/></svg>
           </span>
           <span>Дашборд</span>
         </a>
-        <a href="journal.html" class="sb-link">
+          <a href="journal.html" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="4" y="4" width="16" height="16" rx="2" stroke-width="2"/><path d="M8 8h8M8 12h8M8 16h6" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Журнал</span>
         </a>
-        <a href="analytics.html" class="sb-link">
+          <a href="#/analytics" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18" stroke-width="2"/><path d="M7 16v2M12 10v8M17 6v12" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Аналитика</span>
         </a>
-        <a href="calendar.html" class="sb-link">
+          <a href="#/calendar" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="5" width="18" height="16" rx="2" stroke-width="2"/><path d="M16 3v4M8 3v4M3 10h18" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Календарь</span>
         </a>
-        <a href="goals.html" class="sb-link">
+          <a href="#/goals" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9" stroke-width="2"/><path d="M12 7v10M7 12h10" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Цели</span>
         </a>
-        <a href="accounts.html" class="sb-link">
+          <a href="#/accounts" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="7" r="4" stroke-width="2"/><path d="M5.5 21a6.5 6.5 0 0 1 13 0" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
@@ -290,8 +290,8 @@
       </section>
     </main>
 
-    <!-- SPA Content outlet (not used in multi-page mode, keep for future) -->
-    <div id="view" class="view" style="display:none;"></div>
+    <!-- SPA Content outlet (used when navigating to hash routes) -->
+    <div id="view" class="dashboard" style="display:none;"></div>
 
     <footer class="app-footer app-footer--pro">
       <div class="af-left">

--- a/journal.html
+++ b/journal.html
@@ -50,19 +50,19 @@
           </span>
           <span>Журнал</span>
         </a>
-        <a href="analytics.html" class="sb-link">
+          <a href="index.html#/analytics" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 3v18h18" stroke-width="2"/><path d="M7 16v2M12 10v8M17 6v12" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Аналитика</span>
         </a>
-        <a href="calendar.html" class="sb-link">
+          <a href="index.html#/calendar" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="5" width="18" height="16" rx="2" stroke-width="2"/><path d="M16 3v4M8 3v4M3 10h18" stroke-width="2" stroke-linecap="round"/></svg>
           </span>
           <span>Календарь</span>
         </a>
-        <a href="goals.html" class="sb-link">
+          <a href="index.html#/goals" class="sb-link">
           <span class="ico">
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9" stroke-width="2"/><path d="M12 7v10M7 12h10" stroke-width="2" stroke-linecap="round"/></svg>
           </span>


### PR DESCRIPTION
## Summary
- fix sidebar navigation to use SPA routes for analytics, calendar, goals, and accounts
- show SPA routes in styled container and hide dashboard when navigating away

## Testing
- `for f in assets/js/*.js; do echo "checking $f"; node --check $f; done`


------
https://chatgpt.com/codex/tasks/task_e_6895ef672a2c83338bc1b56b191e6db5